### PR TITLE
Fix issue type environment variable

### DIFF
--- a/src/JiraSecurityIssue.php
+++ b/src/JiraSecurityIssue.php
@@ -72,7 +72,7 @@ class JiraSecurityIssue
     public function __construct()
     {
         $this->project = \getenv('JIRA_PROJECT') ?: '';
-        $this->issueType = \getenv('JIRA_ISSUETYPE') ?: 'Bug';
+        $this->issueType = \getenv('JIRA_ISSUE_TYPE') ?: 'Bug';
 
         $conf = [
             'jiraHost' => \getenv('JIRA_HOST'),

--- a/tests/JiraSecurityIssueTest.php
+++ b/tests/JiraSecurityIssueTest.php
@@ -17,7 +17,7 @@ class JiraSecurityIssueTest extends TestCase
         \putenv('JIRA_USER=user');
         \putenv('JIRA_TOKEN=pass');
         \putenv('JIRA_PROJECT=ABC');
-        \putenv('JIRA_ISSUETYPE=Mytype');
+        \putenv('JIRA_ISSUE_TYPE=Mytype');
         \putenv('JIRA_WATCHERS=');
 
         $this->issueService = $this->prophesize(IssueService::class);


### PR DESCRIPTION
The documentation says the variable name is `JIRA_ISSUE_TYPE` whereas the implementation says `JIRA_ISSUETYPE`.

Fix the implementation to match the documentation (since the only current usage of the library is using the documented name).