### PR TITLE
Fix watchers

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,19 @@
+on: pull_request
+name: Test, check, lint
+jobs:
+  test:
+    name: PHPUnit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup PHP, with composer and extensions
+      uses: shivammathur/setup-php@master
+      with:
+        php-version: 7.3
+        coverage: none
+    - name: Install Dependencies
+      run: |
+        composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+    - name: Run unit tests
+      run: |
+        vendor/bin/phpunit

--- a/src/JiraSecurityIssue.php
+++ b/src/JiraSecurityIssue.php
@@ -279,7 +279,7 @@ class JiraSecurityIssue
 
         $user = \array_pop($users);
 
-        return $user->name;
+        return $user->accountId;
     }
 
     /**

--- a/tests/JiraSecurityIssueTest.php
+++ b/tests/JiraSecurityIssueTest.php
@@ -147,14 +147,14 @@ class JiraSecurityIssueTest extends TestCase
                 'project' => 'ABC',
                 'maxResults' => 1
             ])
-            ->willReturn([(object) ['name' => 'abcd']]);
+            ->willReturn([(object) ['accountId' => 'abcd']]);
         $this->userService
             ->findAssignableUsers([
                 'query' => 'user2@example.com',
                 'project' => 'ABC',
                 'maxResults' => 1
             ])
-            ->willReturn([(object) ['name' => '1234']]);
+            ->willReturn([(object) ['accountId' => '1234']]);
 
         $this->issueService
             ->addWatcher('ABC-15', 'abcd')
@@ -207,14 +207,14 @@ class JiraSecurityIssueTest extends TestCase
                 'project' => 'ABC',
                 'maxResults' => 1
             ])
-            ->willReturn([(object) ['name' => 'abcd']]);
+            ->willReturn([(object) ['accountId' => 'abcd']]);
         $this->userService
             ->findAssignableUsers([
                 'query' => 'user2@example.com',
                 'project' => 'ABC',
                 'maxResults' => 1
             ])
-            ->willReturn([(object) ['name' => '1234']]);
+            ->willReturn([(object) ['accountId' => '1234']]);
 
         $this->issueService
             ->addComment('ABC-17', $issue->createComment("This issue is being followed by [~abcd] and [~1234]"))
@@ -270,14 +270,14 @@ class JiraSecurityIssueTest extends TestCase
                 'project' => 'ABC',
                 'maxResults' => 1
             ])
-            ->willReturn([(object) ['name' => 'abcd']]);
+            ->willReturn([(object) ['accountId' => 'abcd']]);
         $this->userService
             ->findAssignableUsers([
                 'query' => 'user2@example.com',
                 'project' => 'ABC',
                 'maxResults' => 1
             ])
-            ->willReturn([(object) ['name' => '1234']]);
+            ->willReturn([(object) ['accountId' => '1234']]);
         $this->userService
             ->findAssignableUsers([
                 'query' => 'notfound@example.com',


### PR DESCRIPTION
The API no longer returns the user name property. We'll use the account ID instead.