### PR TITLE
Redo handling of watchers

### DIFF
--- a/src/JiraUserInfoCommand.php
+++ b/src/JiraUserInfoCommand.php
@@ -41,7 +41,7 @@ class JiraUserInfoCommand extends Command
 
         $email = $typedInput->getStringArgument('email') ?? '';
 
-        $data = $issue->userDataByEmail($email);
+        $data = $issue->findUser($email);
 
         $output->writeln(\print_r($data, true));
 

--- a/tests/JiraSecurityIssueTest.php
+++ b/tests/JiraSecurityIssueTest.php
@@ -150,14 +150,14 @@ class JiraSecurityIssueTest extends TestCase
                 'project' => 'ABC',
                 'maxResults' => 1,
             ])
-            ->willReturn([new User(['accountId' => 'abcd'])]);
+            ->willReturn([new User(['accountId' => 'abcd', 'displayName' => 'efgh'])]);
         $this->userService
             ->findAssignableUsers([
                 'query' => 'user2@example.com',
                 'project' => 'ABC',
                 'maxResults' => 1,
             ])
-            ->willReturn([new User(['accountId' => '1234'])]);
+            ->willReturn([new User(['accountId' => '1234', 'displayName' => '5678'])]);
 
         $this->issueService
             ->addWatcher('ABC-15', 'abcd')
@@ -209,17 +209,17 @@ class JiraSecurityIssueTest extends TestCase
                 'project' => 'ABC',
                 'maxResults' => 1,
             ])
-            ->willReturn([new User(['accountId' => 'abcd'])]);
+            ->willReturn([new User(['accountId' => 'abcd', 'displayName' => 'efgh'])]);
         $this->userService
             ->findAssignableUsers([
                 'query' => 'user2@example.com',
                 'project' => 'ABC',
                 'maxResults' => 1,
             ])
-            ->willReturn([new User(['accountId' => '1234'])]);
+            ->willReturn([new User(['accountId' => '1234', 'displayName' => '5678'])]);
 
         $this->issueService
-            ->addComment('ABC-17', $issue->createComment("This issue is being followed by [~abcd] and [~1234]"))
+            ->addComment('ABC-17', $issue->createComment("This issue is being followed by efgh and 5678"))
             ->shouldBeCalled();
 
         $issue
@@ -242,7 +242,10 @@ class JiraSecurityIssueTest extends TestCase
     {
         $issue = $this->newIssue();
 
-        $this->assertEquals('[~one] and [~two]', $issue->formatUsers(['one', 'two']));
+        $this->assertEquals(
+            'one and two',
+            $issue->formatUsers([new User(['displayName' => 'one']), new User(['displayName' => 'two'])]),
+        );
     }
 
     public function testQuotedFormatting(): void
@@ -272,14 +275,14 @@ class JiraSecurityIssueTest extends TestCase
                 'project' => 'ABC',
                 'maxResults' => 1,
             ])
-            ->willReturn([new User(['accountId' => 'abcd'])]);
+            ->willReturn([new User(['accountId' => 'abcd', 'displayName' => 'efgh'])]);
         $this->userService
             ->findAssignableUsers([
                 'query' => 'user2@example.com',
                 'project' => 'ABC',
                 'maxResults' => 1,
             ])
-            ->willReturn([new User(['accountId' => '1234'])]);
+            ->willReturn([new User(['accountId' => '1234', 'displayName' => '5678'])]);
         $this->userService
             ->findAssignableUsers([
                 'query' => 'notfound@example.com',
@@ -299,7 +302,7 @@ class JiraSecurityIssueTest extends TestCase
             ->addComment(
                 'ABC-17',
                 $issue->createComment(
-                    "This issue is being followed by [~abcd] and [~1234]\n\n" .
+                    "This issue is being followed by efgh and 5678\n\n" .
                     "Could not find user for \"notfound@example.com\" and \"notfoundeither@example.com\"," .
                     " please check the users listed in JIRA_WATCHERS.",
                 ),


### PR DESCRIPTION
Atlassian removed the user `name` from the API result.

Instead we are supposed to use the `accountId`.

`accountId` works fine for adding watchers.

But we cannot use it to mention the user inline in a comment (they claim we should be -- but it doesn't work).

This commit refactors the stuff into using `accountId` for adding the watchers and the uses the `displayName` in the comment -- but as clear text, not a mention. That'll have to do now since it is just what's possible.

To be able to use both `accountId` and `displayName` we need some refactoring. In this case moving the `\JiraRestApi\User\User` object around instead of just passing the user name/accoundId around as a string.