### PR TITLE
Make restricted comment role configurable

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Reload A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ CI systems.
 - `JIRA_ISSUE_TYPE`: Type of issue to create, e.g. `Security`. Defaults to `Bug`. (*Optional*)
 - `JIRA_WATCHERS`: Jira users to add as watchers to tickets. Separate
   multiple watchers with comma (no spaces). (*Optional*)
+- `JIRA_RESTRICTED_COMMENT_ROLE`: A comment with restricted visibility
+  to this role is posted with info about who was added as watchers to
+  the issue. Defaults to `Developers`. (*Optional*)

--- a/src/JiraSecurityIssue.php
+++ b/src/JiraSecurityIssue.php
@@ -51,6 +51,13 @@ class JiraSecurityIssue
     protected $issueType = 'Bug';
 
     /**
+     * Role that restricted comments are visible to.
+     *
+     * @var string
+     */
+    protected $restrictedCommentRole = 'Developers';
+
+    /**
      * Watchers for the issue.
      *
      * @var array<string>
@@ -82,6 +89,7 @@ class JiraSecurityIssue
     {
         $this->project = \getenv('JIRA_PROJECT') ?: '';
         $this->issueType = \getenv('JIRA_ISSUE_TYPE') ?: 'Bug';
+        $this->restrictedCommentRole = \getenv('JIRA_RESTRICTED_COMMENT_ROLE') ?: 'Developers';
 
         $watchers = \getenv('JIRA_WATCHERS');
 
@@ -313,7 +321,7 @@ class JiraSecurityIssue
 
         $visibility = new Visibility();
         $visibility->setType('role');
-        $visibility->setValue('Developers');
+        $visibility->setValue($this->restrictedCommentRole);
 
         $comment->visibility = $visibility;
 


### PR DESCRIPTION
It was hard coded to `Developers` which is not a guaranteed role in Jira.

This makes it configurable but uses `Developers` as default value for backward compatibility.