### PR TITLE
Bump version on merge to master

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,18 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.23.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DEFAULT_BUMP: patch


### PR DESCRIPTION
Use https://github.com/anothrNick/github-tag-action to bump the version:

> Manual Bumping: Any commit message that includes #major, #minor, or #patch will trigger the respective version bump. If two or more are present, the highest-ranking one will take precedence.
>
> Automatic Bumping: If no #major, #minor or #patch tag is contained in the commit messages, it will bump whichever DEFAULT_BUMP is set to (which is minor by default). Disable this by setting DEFAULT_BUMP to none.

We haven't released tagged versions of this library before. Let's start doing that so the tools depending on this can received PR's from @dependabot.

I have set `DEFAULT_BUMP` to `patch` because most PR's will be form Dependabot and that will be changes to dependencies only with no new features or braking changes (if there is breakage the tests should fail, and we will notice).