### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,6 +3,9 @@ on:
   - push
 
 name: Test, check, lint
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   test:
     name: PHPUnit


### PR DESCRIPTION
Potential fix for [https://github.com/reload/jira-security-issue/security/code-scanning/4](https://github.com/reload/jira-security-issue/security/code-scanning/4)

The best fix is to add an explicit `permissions` block to the workflow at the root level in `.github/workflows/pull_request.yml`. The minimum required permissions for this workflow appear to be `contents: read` and `pull-requests: write`, because the jobs post results to pull requests (via Reviewdog) and need to access code. Add the following block after the `name: ...` entry and before the `jobs:` key:

```yaml
permissions:
  contents: read
  pull-requests: write
```

This change should be added at the root (global) level so all jobs inherit these minimal permissions unless overridden. There is no need to add or edit imports, methods, or other regions. No other changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
