### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -6,6 +6,8 @@ on:
     types:
       - completed
 
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/reload/jira-security-issue/security/code-scanning/2](https://github.com/reload/jira-security-issue/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` block that grants only the minimum permissions required by the workflow to successfully run. In this case, the workflow uses `anothrNick/github-tag-action` to create tags and push them to the repository, which requires `contents: write`. The `permissions` block should be added at the job level (or at the root level) for clarity and maintainability, explicitly setting `contents: write`. This should be added right before the `jobs:` key if setting globally, or inside `build:` if setting per job. Since there's only one job, it is simplest and most future-proof to set at the workflow root (above `jobs:`).

No new methods or external imports are needed; the change is to the YAML only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
